### PR TITLE
Add Cancellable Interaction for Presentation Animation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,90 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.pins
+# Package.resolved
+# *.xcodeproj
+#
+# Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
+# hence it is not needed unless you have added a package configuration file to your project
+# .swiftpm
+
+.build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# Accio dependency management
+Dependencies/
+.accio/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/

--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -311,13 +311,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6LF3GMKZAB;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = dev.tim.ChidoriMenuExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.christianselig.ChidoriMenuExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -330,13 +330,13 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 6LF3GMKZAB;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = dev.tim.ChidoriMenuExample;
+				PRODUCT_BUNDLE_IDENTIFIER = com.christianselig.ChidoriMenuExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -1,0 +1,374 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		22109B7225E166EC00C1B423 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 22109B6925E166EC00C1B423 /* Assets.xcassets */; };
+		22109B7325E166EC00C1B423 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22109B6A25E166EC00C1B423 /* LaunchScreen.storyboard */; };
+		22109B7425E166EC00C1B423 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 22109B6C25E166EC00C1B423 /* Main.storyboard */; };
+		22109B7525E166EC00C1B423 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22109B6E25E166EC00C1B423 /* AppDelegate.swift */; };
+		22109B7725E166EC00C1B423 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22109B7025E166EC00C1B423 /* SceneDelegate.swift */; };
+		22109B8125E1677400C1B423 /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22109B7C25E1677400C1B423 /* ExampleViewController.swift */; };
+		22109B8225E1677400C1B423 /* ChidoriMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22109B7D25E1677400C1B423 /* ChidoriMenu.swift */; };
+		22109B8325E1677500C1B423 /* ChidoriPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22109B7E25E1677400C1B423 /* ChidoriPresentationController.swift */; };
+		22109B8425E1677500C1B423 /* ChidoriMenuTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22109B7F25E1677400C1B423 /* ChidoriMenuTableViewCell.swift */; };
+		22109B8525E1677500C1B423 /* ChidoriAnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22109B8025E1677400C1B423 /* ChidoriAnimationController.swift */; };
+		22109B8925E16AE000C1B423 /* ChidoriOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22109B8825E16AE000C1B423 /* ChidoriOverlayView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		22109B4D25E166AC00C1B423 /* ChidoriMenuExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChidoriMenuExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		22109B6925E166EC00C1B423 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		22109B6B25E166EC00C1B423 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		22109B6D25E166EC00C1B423 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		22109B6E25E166EC00C1B423 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		22109B6F25E166EC00C1B423 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		22109B7025E166EC00C1B423 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		22109B7C25E1677400C1B423 /* ExampleViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExampleViewController.swift; sourceTree = "<group>"; };
+		22109B7D25E1677400C1B423 /* ChidoriMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChidoriMenu.swift; sourceTree = "<group>"; };
+		22109B7E25E1677400C1B423 /* ChidoriPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChidoriPresentationController.swift; sourceTree = "<group>"; };
+		22109B7F25E1677400C1B423 /* ChidoriMenuTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChidoriMenuTableViewCell.swift; sourceTree = "<group>"; };
+		22109B8025E1677400C1B423 /* ChidoriAnimationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChidoriAnimationController.swift; sourceTree = "<group>"; };
+		22109B8825E16AE000C1B423 /* ChidoriOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChidoriOverlayView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		22109B4A25E166AC00C1B423 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		22109B4425E166AC00C1B423 = {
+			isa = PBXGroup;
+			children = (
+				22109B7B25E1677400C1B423 /* Source */,
+				22109B6725E166EC00C1B423 /* Example */,
+				22109B4E25E166AC00C1B423 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		22109B4E25E166AC00C1B423 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				22109B4D25E166AC00C1B423 /* ChidoriMenuExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		22109B6725E166EC00C1B423 /* Example */ = {
+			isa = PBXGroup;
+			children = (
+				22109B6925E166EC00C1B423 /* Assets.xcassets */,
+				22109B6A25E166EC00C1B423 /* LaunchScreen.storyboard */,
+				22109B6C25E166EC00C1B423 /* Main.storyboard */,
+				22109B6E25E166EC00C1B423 /* AppDelegate.swift */,
+				22109B6F25E166EC00C1B423 /* Info.plist */,
+				22109B7025E166EC00C1B423 /* SceneDelegate.swift */,
+			);
+			path = Example;
+			sourceTree = "<group>";
+		};
+		22109B7B25E1677400C1B423 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				22109B7C25E1677400C1B423 /* ExampleViewController.swift */,
+				22109B7D25E1677400C1B423 /* ChidoriMenu.swift */,
+				22109B7E25E1677400C1B423 /* ChidoriPresentationController.swift */,
+				22109B7F25E1677400C1B423 /* ChidoriMenuTableViewCell.swift */,
+				22109B8825E16AE000C1B423 /* ChidoriOverlayView.swift */,
+				22109B8025E1677400C1B423 /* ChidoriAnimationController.swift */,
+			);
+			path = Source;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		22109B4C25E166AC00C1B423 /* ChidoriMenuExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 22109B6125E166AD00C1B423 /* Build configuration list for PBXNativeTarget "ChidoriMenuExample" */;
+			buildPhases = (
+				22109B4925E166AC00C1B423 /* Sources */,
+				22109B4A25E166AC00C1B423 /* Frameworks */,
+				22109B4B25E166AC00C1B423 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ChidoriMenuExample;
+			productName = ChidoriMenuExample;
+			productReference = 22109B4D25E166AC00C1B423 /* ChidoriMenuExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		22109B4525E166AC00C1B423 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1230;
+				LastUpgradeCheck = 1230;
+				TargetAttributes = {
+					22109B4C25E166AC00C1B423 = {
+						CreatedOnToolsVersion = 12.3;
+					};
+				};
+			};
+			buildConfigurationList = 22109B4825E166AC00C1B423 /* Build configuration list for PBXProject "Example" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 22109B4425E166AC00C1B423;
+			productRefGroup = 22109B4E25E166AC00C1B423 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				22109B4C25E166AC00C1B423 /* ChidoriMenuExample */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		22109B4B25E166AC00C1B423 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				22109B7425E166EC00C1B423 /* Main.storyboard in Resources */,
+				22109B7225E166EC00C1B423 /* Assets.xcassets in Resources */,
+				22109B7325E166EC00C1B423 /* LaunchScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		22109B4925E166AC00C1B423 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				22109B7525E166EC00C1B423 /* AppDelegate.swift in Sources */,
+				22109B8225E1677400C1B423 /* ChidoriMenu.swift in Sources */,
+				22109B8925E16AE000C1B423 /* ChidoriOverlayView.swift in Sources */,
+				22109B8525E1677500C1B423 /* ChidoriAnimationController.swift in Sources */,
+				22109B8325E1677500C1B423 /* ChidoriPresentationController.swift in Sources */,
+				22109B8425E1677500C1B423 /* ChidoriMenuTableViewCell.swift in Sources */,
+				22109B8125E1677400C1B423 /* ExampleViewController.swift in Sources */,
+				22109B7725E166EC00C1B423 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		22109B6A25E166EC00C1B423 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				22109B6B25E166EC00C1B423 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		22109B6C25E166EC00C1B423 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				22109B6D25E166EC00C1B423 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		22109B5F25E166AD00C1B423 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		22109B6025E166AD00C1B423 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		22109B6225E166AD00C1B423 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 6LF3GMKZAB;
+				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = dev.tim.ChidoriMenuExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		22109B6325E166AD00C1B423 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 6LF3GMKZAB;
+				INFOPLIST_FILE = "$(SRCROOT)/Example/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = dev.tim.ChidoriMenuExample;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		22109B4825E166AC00C1B423 /* Build configuration list for PBXProject "Example" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				22109B5F25E166AD00C1B423 /* Debug */,
+				22109B6025E166AD00C1B423 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		22109B6125E166AD00C1B423 /* Build configuration list for PBXNativeTarget "ChidoriMenuExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				22109B6225E166AD00C1B423 /* Debug */,
+				22109B6325E166AD00C1B423 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 22109B4525E166AC00C1B423 /* Project object */;
+}

--- a/Example.xcodeproj/project.pbxproj
+++ b/Example.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		22109B8325E1677500C1B423 /* ChidoriPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22109B7E25E1677400C1B423 /* ChidoriPresentationController.swift */; };
 		22109B8425E1677500C1B423 /* ChidoriMenuTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22109B7F25E1677400C1B423 /* ChidoriMenuTableViewCell.swift */; };
 		22109B8525E1677500C1B423 /* ChidoriAnimationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22109B8025E1677400C1B423 /* ChidoriAnimationController.swift */; };
-		22109B8925E16AE000C1B423 /* ChidoriOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22109B8825E16AE000C1B423 /* ChidoriOverlayView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -33,7 +32,6 @@
 		22109B7E25E1677400C1B423 /* ChidoriPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChidoriPresentationController.swift; sourceTree = "<group>"; };
 		22109B7F25E1677400C1B423 /* ChidoriMenuTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChidoriMenuTableViewCell.swift; sourceTree = "<group>"; };
 		22109B8025E1677400C1B423 /* ChidoriAnimationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChidoriAnimationController.swift; sourceTree = "<group>"; };
-		22109B8825E16AE000C1B423 /* ChidoriOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChidoriOverlayView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -84,7 +82,6 @@
 				22109B7D25E1677400C1B423 /* ChidoriMenu.swift */,
 				22109B7E25E1677400C1B423 /* ChidoriPresentationController.swift */,
 				22109B7F25E1677400C1B423 /* ChidoriMenuTableViewCell.swift */,
-				22109B8825E16AE000C1B423 /* ChidoriOverlayView.swift */,
 				22109B8025E1677400C1B423 /* ChidoriAnimationController.swift */,
 			);
 			path = Source;
@@ -162,7 +159,6 @@
 			files = (
 				22109B7525E166EC00C1B423 /* AppDelegate.swift in Sources */,
 				22109B8225E1677400C1B423 /* ChidoriMenu.swift in Sources */,
-				22109B8925E16AE000C1B423 /* ChidoriOverlayView.swift in Sources */,
 				22109B8525E1677500C1B423 /* ChidoriAnimationController.swift in Sources */,
 				22109B8325E1677500C1B423 /* ChidoriPresentationController.swift in Sources */,
 				22109B8425E1677500C1B423 /* ChidoriMenuTableViewCell.swift in Sources */,

--- a/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  ChidoriMenuExample
+//
+//  Created by Tim Oliver on 21/2/21.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/Example/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Example/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Assets.xcassets/Contents.json
+++ b/Example/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Example/Base.lproj/LaunchScreen.storyboard
+++ b/Example/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Example View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ExampleViewController" customModule="ChidoriMenuExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="103" y="108"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Example/Info.plist
+++ b/Example/Info.plist
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Example/SceneDelegate.swift
+++ b/Example/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  ChidoriMenuExample
+//
+//  Created by Tim Oliver on 21/2/21.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/Source/ChidoriAnimationController.swift
+++ b/Source/ChidoriAnimationController.swift
@@ -7,12 +7,14 @@
 
 import UIKit
 
-class ChidoriAnimationController: NSObject, UIViewControllerAnimatedTransitioning {
+class ChidoriAnimationController: NSObject, UIViewControllerAnimatedTransitioning, UIViewControllerInteractiveTransitioning {
     enum AnimationControllerType { case presentation, dismissal }
     
     let type: AnimationControllerType
     
     var animatorForCurrentSession: UIViewPropertyAnimator?
+
+    weak var context: UIViewControllerContextTransitioning?
     
     init(type: AnimationControllerType) {
         self.type = type
@@ -20,6 +22,24 @@ class ChidoriAnimationController: NSObject, UIViewControllerAnimatedTransitionin
     
     func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
         return 0.4
+    }
+
+    func startInteractiveTransition(_ transitionContext: UIViewControllerContextTransitioning) {
+        context = transitionContext
+        animateTransition(using: transitionContext)
+    }
+
+     func cancelTransition() {
+        guard let context = context,
+              let animator = animatorForCurrentSession else { return }
+
+         // Cancel the current transition
+        context.cancelInteractiveTransition()
+
+         // Play the animation in reverse
+        animator.pauseAnimation()
+        animator.isReversed = true
+        animator.startAnimation()
     }
     
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
@@ -75,7 +95,6 @@ class ChidoriAnimationController: NSObject, UIViewControllerAnimatedTransitionin
         }
         
         propertyAnimator.addCompletion { (position) in
-            guard position == .end else { return }
             transitionContext.completeTransition(!transitionContext.transitionWasCancelled)
             self.animatorForCurrentSession = nil
         }

--- a/Source/ChidoriAnimationController.swift
+++ b/Source/ChidoriAnimationController.swift
@@ -37,7 +37,6 @@ class ChidoriAnimationController: NSObject, UIViewControllerAnimatedTransitionin
         context.cancelInteractiveTransition()
 
          // Play the animation in reverse
-        animator.pauseAnimation()
         animator.isReversed = true
         animator.startAnimation()
     }

--- a/Source/ChidoriAnimationController.swift
+++ b/Source/ChidoriAnimationController.swift
@@ -39,17 +39,35 @@ class ChidoriAnimationController: NSObject, UIViewControllerAnimatedTransitionin
          // Play the animation in reverse
         animator.isReversed = true
         animator.startAnimation()
+
+        if type == .presentation {
+            if let presentingViewController = context.viewController(forKey: .from) {
+                presentingViewController.view.tintAdjustmentMode = .automatic
+            } else {
+                preconditionFailure("Presenting view controller should be accessible")
+            }
+        }
     }
     
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         let interruptableAnimator = interruptibleAnimator(using: transitionContext)
-        
+
         if type == .presentation {
             if let chidoriMenu: ChidoriMenu = transitionContext.viewController(forKey: UITransitionContextViewControllerKey.to) as? ChidoriMenu {
                 transitionContext.containerView.addSubview(chidoriMenu.view)
             }
+
+            if let presentingViewController = transitionContext.viewController(forKey: .from) {
+                presentingViewController.view.tintAdjustmentMode = .dimmed
+            } else {
+                preconditionFailure("Presenting view controller should be accessible")
+            }
+        } else {
+            if let presentingViewController = transitionContext.viewController(forKey: .to) {
+                presentingViewController.view.tintAdjustmentMode = .automatic
+            }
         }
-        
+
         interruptableAnimator.startAnimation()
     }
         

--- a/Source/ChidoriPresentationController.swift
+++ b/Source/ChidoriPresentationController.swift
@@ -7,10 +7,16 @@
 
 import UIKit
 
+protocol ChidoriPresentationControllerDelegate: NSObjectProtocol {
+    func didTapOverlayView(_ chidoriPresentationController: ChidoriPresentationController)
+}
+
 class ChidoriPresentationController: UIPresentationController {
     let darkOverlayView: UIView = UIView()
     let tapGestureRecognizer = UITapGestureRecognizer(target: nil, action: nil)
-    
+
+    weak var transitionDelegate: ChidoriPresentationControllerDelegate?
+
     // MARK: - Animation Lifecycle
     
     override func presentationTransitionWillBegin() {
@@ -127,6 +133,6 @@ class ChidoriPresentationController: UIPresentationController {
     // MARK: - Target Action
     
     @objc private func tappedDarkOverlayView(tapGestureRecognizer: UITapGestureRecognizer) {
-        presentedViewController.dismiss(animated: true, completion: nil)
+        transitionDelegate?.didTapOverlayView(self)
     }
 }


### PR DESCRIPTION
Hey @christianselig!

As promised, I had a bit of a play with making the opening presentation animation and I got it working! :D

Here's the things I changed:

* I modified `ChidoriAnimationController` to also conform to the interactive controller protocol, and modified `ChidoriMenu` to retain and provide the same instance to both animation and interactive delegates.
* I included a public `cancel` method that retains the context of the animation to allow cancellations, and also stops, and then restarts the "opening" animation in reverse.
* When a presentation starts, it is treated as interactive from the start, meaning touches automatically work by default.
* When the user taps the dimming view, this now forwards the tap through a delegate pattern to `ChidoriMenu`
* Chidori menu then calls the cancellation method, but if the animation has already completed, it also calls `dismiss` to dismiss it as normal.

I've also included a small Xcode project in order to make it super quick to test this out. I'd also recommend adding CocoaPods and Swift Package Manager support (or if you'd like, I can do that).

Please try it out, and let me know what you think. There might be some better ways to streamline this logic and code organization, but this should hopefully be a good start.

All the best!